### PR TITLE
chore: update pnpm version in CI/CD workflow and remove NPM version l…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
-        version: 9
+        version: 9.12.2
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -47,7 +47,6 @@ jobs:
     - name: Install dependencies
       run: |
         echo "Node version: $(node --version)"
-        echo "NPM version: $(npm --version)"
         echo "PNPM version: $(pnpm --version)"
         echo "Installing dependencies..."
         pnpm install --frozen-lockfile


### PR DESCRIPTION
…ogging

- Updated pnpm version to 9.12.2 in the CI/CD workflow.
- Removed logging of NPM version during dependency installation for cleaner output.